### PR TITLE
Several minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Build process currently uses ant. To build, you can run the build script.
 
 Requirements are moreutils, java, jdk and ant. On ubuntu:
 
-	sudo aptitude install moreutils default-jre default-jdk ant
+	sudo aptitude install moreutils openjdk-7-jre openjdk-7-jdk ant
 
 On OS X install JDK manually. moreutils and ant can be installed with homebrew
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,18 @@ Build process currently uses ant. To build, you can run the build script.
 
 ## Running
 
+Requirements are moreutils, java, jdk and ant. On ubuntu:
+
+	sudo aptitude install moreutils default-jre default-jdk ant
+
+On OS X install JDK manually. moreutils and ant can be installed with homebrew
+
+	brew install ant moreutils
+
 Running requires a somewhat complex command, so the codebase includes run.sh script for that.
 To start walletd, run:
-`sh run.sh`
+
+	`sh run.sh`
 
 Walletd supports both mainnet and testnet. Default configuration will run both at once.
 Wallet file for mainnet is `mainnet.wallet` and for testnet `testnet.wallet`.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ The repository also includes a tool for manipulating bitcoinj wallet files. It's
 the wallet file directly. For example if you want to make a backup of the wallet's seed or restore a wallet from
 a seed. This tool was gratefully swiped from the bitcoinj repository.
 
+### Creating wallet
+
+Mainnet:
+```
+sh wallet-tool.sh create --wallet=mainnet.wallet
+```
+
+Testnet:
+```
+sh wallet-tool.sh create --wallet=testnet.wallet --net=TEST
+```
+
+These commands will create files mainnet.wallet and testnet.wallet, which will contain unencrypted wallet data.
+
 ### Backing up the wallet seed
 
 Mainnet wallet: `sh wallet-tool.sh dump --wallet=mainnet.wallet --dump-privkeys | grep Seed`

--- a/src/fi/bittiraha/walletd/Main.java
+++ b/src/fi/bittiraha/walletd/Main.java
@@ -2,6 +2,7 @@ package fi.bittiraha.walletd;
 
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.params.MainNetParams;
+import fi.bittiraha.util.ConfigFile;
 import fi.bittiraha.walletd.WalletRPC;
 
 public class Main {

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -496,9 +496,9 @@ public class WalletRPC extends Thread implements RequestHandler {
           break;
         case "estimatefee":
           // recommended not to use this function, but if used, try to return something sensible
-          if ((long)rp.get(0) < 3L) { response = "0.00052186"; }
-          else if ((long)rp.get(0) < 6L) { response = "0.00018234"; }
-          else { response = "0.00017992"; }
+          if ((long)rp.get(0) < 3L) { response = "0.00026186"; }
+          else if ((long)rp.get(0) < 6L) { response = "0.00010234"; }
+          else { response = "0.00008992"; }
           break;
         case "getinfo":
           response = getinfo();

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -73,6 +73,7 @@ public class WalletRPC extends Thread implements RequestHandler {
     config.defaultInteger("targetCoinCount",8);
     config.defaultBigDecimal("targetCoinAmount", new BigDecimal("0.5"));
     config.defaultInteger("port",port);
+    config.defaultBoolean("useTor",false);
 
     config.defaultBoolean("randomizeChangeOutputs", false);
 
@@ -94,6 +95,11 @@ public class WalletRPC extends Thread implements RequestHandler {
     try {
       log.info(filePrefix + ": wallet starting.");
       kit = new WalletApp(params, new File("."), filePrefix);
+
+      if (config.getBoolean("useTor"))
+      {
+        kit.useTor();
+      }
 
       kit.startAsync();
       server = new JSONRPC2Handler(port, this);

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -74,8 +74,7 @@ public class WalletRPC extends Thread implements RequestHandler {
     config.defaultBigDecimal("targetCoinAmount", new BigDecimal("0.5"));
     config.defaultInteger("port",port);
 
-    config.defaultBigDecimal("randomMultiChangeMin", new BigDecimal("0.1"));
-    config.defaultBigDecimal("randomMultiChangeMax", new BigDecimal("0"));
+    config.defaultBoolean("multipleRandomChange", false);
 
     this.port = config.getInteger("port");
 
@@ -178,12 +177,13 @@ public class WalletRPC extends Thread implements RequestHandler {
     Coin change = totalIn.subtract(totalOut);
     Coin target = Coin.parseCoin(config.getBigDecimal("targetCoinAmount").toString());
 
-    if (config.getBigDecimal("randomMultiChangeMax") > BigDecimal(0))
+    if (config.getBoolean("multipleRandomChange"))
     {
       Coin remainingChange = change;
-      while (remainingChange > )
+      while (remainingChange > config.getBigDecimal("randomMultiChangeMax"))
       {
-        
+        long extraChange = Math.min(pieces, (long) config.getInteger("targetCoinCount") - getConfirmedCoinCount());
+        BigDecimal randFromDouble = new BigDecimal(Math.random());
       }
     }
     else

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -74,6 +74,18 @@ public class WalletRPC extends Thread implements RequestHandler {
     config.defaultBigDecimal("targetCoinAmount", new BigDecimal("0.5"));
     config.defaultInteger("port",port);
 
+    // Note, tor support seems to be very unstable - not recommended
+    config.defaultBoolean("useTor",false);
+
+    config.defaultString("socksProxyHost","");
+    config.defaultString("socksProxyPort","");
+
+    if (config.getString("socksProxyHost") != "" && config.getString("socksProxyPort") != "")
+    {
+      System.setProperty("socksProxyHost", config.getString("socksProxyHost"));
+      System.setProperty("socksProxyPort", config.getString("socksProxyPort"));
+    }
+
     config.defaultBoolean("randomizeChangeOutputs", false);
 
     this.port = config.getInteger("port");
@@ -94,6 +106,11 @@ public class WalletRPC extends Thread implements RequestHandler {
     try {
       log.info(filePrefix + ": wallet starting.");
       kit = new WalletApp(params, new File("."), filePrefix);
+
+      if (config.getBoolean("useTor"))
+      {
+        kit.useTor();
+      }
 
       kit.startAsync();
       server = new JSONRPC2Handler(port, this);

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -118,7 +118,8 @@ public class WalletRPC extends Thread implements RequestHandler {
       "sendonce",
       "validateaddress",
       "settxfee",
-      "listunspent"
+      "listunspent",
+      "estimate_fee"
     };
   }
 
@@ -474,6 +475,12 @@ public class WalletRPC extends Thread implements RequestHandler {
           break;
         case "validateaddress":
           response = validateaddress((String)rp.get(0));
+          break;
+        case "estimate_fee":
+          // recommended not to use this function, but if used, try to return something sensible
+          if ((long)rp.get(0) < 3L) { response = "0.00052186"; }
+          else if ((long)rp.get(0) < 6L) { response = "0.00018234"; }
+          else { response = "0.00017992"; }
           break;
         case "getinfo":
           response = getinfo();

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -504,7 +504,7 @@ public class WalletRPC extends Thread implements RequestHandler {
           break;
       }
     } catch (InsufficientMoneyException e) {
-      JSONRPC2Error error = new JSONRPC2Error(-6,"Insufficient funds",e.getMessage());
+      JSONRPC2Error error = new JSONRPC2Error(-6,"Insufficient funds");
       return new JSONRPC2Response(error,req.getID());
     } catch (AddressFormatException e) {
       JSONRPC2Error error = new JSONRPC2Error(-5,"Invalid Bitcoin address",e.getMessage());

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -137,7 +137,7 @@ public class WalletRPC extends Thread implements RequestHandler {
       "validateaddress",
       "settxfee",
       "listunspent",
-      "estimate_fee"
+      "estimatefee"
     };
   }
 
@@ -494,7 +494,7 @@ public class WalletRPC extends Thread implements RequestHandler {
         case "validateaddress":
           response = validateaddress((String)rp.get(0));
           break;
-        case "estimate_fee":
+        case "estimatefee":
           // recommended not to use this function, but if used, try to return something sensible
           if ((long)rp.get(0) < 3L) { response = "0.00052186"; }
           else if ((long)rp.get(0) < 6L) { response = "0.00018234"; }

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -74,6 +74,9 @@ public class WalletRPC extends Thread implements RequestHandler {
     config.defaultBigDecimal("targetCoinAmount", new BigDecimal("0.5"));
     config.defaultInteger("port",port);
 
+    config.defaultBigDecimal("randomMultiChangeMin", new BigDecimal("0.1"));
+    config.defaultBigDecimal("randomMultiChangeMax", new BigDecimal("0"));
+
     this.port = config.getInteger("port");
 
     //defaults.setProperty("trustedPeer","1.2.3.4");
@@ -174,14 +177,26 @@ public class WalletRPC extends Thread implements RequestHandler {
     }
     Coin change = totalIn.subtract(totalOut);
     Coin target = Coin.parseCoin(config.getBigDecimal("targetCoinAmount").toString());
-    long pieces = change.divide(target);
-    long extraChange = Math.min(pieces, (long) config.getInteger("targetCoinCount") - getConfirmedCoinCount());
-    if (extraChange > 0) {
-      Coin extraChangeAmount = change.divide(extraChange + 1);
-      for (int i=0;i<extraChange;i++) {
-        tx.addOutput(extraChangeAmount,kit.wallet().freshAddress(KeyChain.KeyPurpose.CHANGE));
+
+    if (config.getBigDecimal("randomMultiChangeMax") > BigDecimal(0))
+    {
+      Coin remainingChange = change;
+      while (remainingChange > )
+      {
+        
       }
-      log.info("Added " + extraChange + " extra change outputs of " + extraChangeAmount.toFriendlyString() + " each.");
+    }
+    else
+    {
+      long pieces = change.divide(target);
+      long extraChange = Math.min(pieces, (long) config.getInteger("targetCoinCount") - getConfirmedCoinCount());
+      if (extraChange > 0) {
+        Coin extraChangeAmount = change.divide(extraChange + 1);
+        for (int i=0;i<extraChange;i++) {
+          tx.addOutput(extraChangeAmount,kit.wallet().freshAddress(KeyChain.KeyPurpose.CHANGE));
+        }
+        log.info("Added " + extraChange + " extra change outputs of " + extraChangeAmount.toFriendlyString() + " each.");
+      }
     }
     return tx;
   }

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -183,8 +183,9 @@ public class WalletRPC extends Thread implements RequestHandler {
       if (config.getBoolean("randomizeChangeOutputs"))
       {
         while (target.compareTo(change) <= 0) {
+          double changeLeft = (double)(change.subtract(target).longValue()) * 0.00000001;
           double min = Math.min(config.getBigDecimal("targetCoinAmount").doubleValue() * 0.25, 0.01);
-          double max = Math.min(config.getBigDecimal("targetCoinAmount").doubleValue() * 2.0, 0.02);
+          double max = Math.min(config.getBigDecimal("targetCoinAmount").doubleValue() * 2.0, changeLeft);
           double randomOutput = min + (max - min) * Math.random();
           Coin extraChangeAmount = Coin.parseCoin(Double.toString(randomOutput));
           tx.addOutput(extraChangeAmount,kit.wallet().freshAddress(KeyChain.KeyPurpose.CHANGE));

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -72,6 +72,10 @@ public class WalletRPC extends Thread implements RequestHandler {
     config.defaultBoolean("sendUnconfirmedChange",true);
     config.defaultInteger("targetCoinCount",8);
     config.defaultBigDecimal("targetCoinAmount", new BigDecimal("0.5"));
+    config.defaultInteger("port",port);
+
+    this.port = getInteger("port");
+
     //defaults.setProperty("trustedPeer","1.2.3.4");
   }
 

--- a/src/fi/bittiraha/walletd/WalletRPC.java
+++ b/src/fi/bittiraha/walletd/WalletRPC.java
@@ -74,7 +74,7 @@ public class WalletRPC extends Thread implements RequestHandler {
     config.defaultBigDecimal("targetCoinAmount", new BigDecimal("0.5"));
     config.defaultInteger("port",port);
 
-    this.port = getInteger("port");
+    this.port = config.getInteger("port");
 
     //defaults.setProperty("trustedPeer","1.2.3.4");
   }


### PR DESCRIPTION
- port is configurable
- changed error message to match that returned by bitcoin core
- randomizeChangeOutputs option, which creates multi-output random changes
- estimatefee call added, not recommended to be used. but if used, returns something sensible
- added tor and socks proxy configuration options (neither are recommended)
- added documentation for setup, now should be easy for ubuntu & os x.
